### PR TITLE
Array pagination problems

### DIFF
--- a/lib/mongoid/data_table/proxy.rb
+++ b/lib/mongoid/data_table/proxy.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'uri'
+require 'kaminari'
 
 module Mongoid
   module DataTable
@@ -44,7 +45,7 @@ module Mongoid
 
       def collection(force = false)
         reload if force
-        @collection ||= conditions.page(current_page).per(per_page)
+        @collection ||= Kaminari.paginate_array(conditions).page(current_page).per(per_page)
       end
 
       def reload


### PR DESCRIPTION
This commit fixes the `undefined method 'page' for #<Array:...` error with Kaminari pagination.
